### PR TITLE
feat: ✨ レスポンシブデザイン改善とAIモデル比較機能を実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,8 @@ cp .env.example .env.local    # Copy environment template
 ```
 Firestore:
 rooms/{roomId} → { name, createdAt, userId }
-  └── messages/{messageId} → { text, sender, createdAt }
+  └── messages/{messageId} → { text, sender, createdAt, isRead, readAt }
+users/{userId}/favorites/{favoriteId} → { messageId, roomId, messageText, createdAt, timestamp }
 ```
 
 **AI Integration:**
@@ -81,6 +82,15 @@ Required in `chatapp/.env.local`:
 - **Solution**: `Chat.tsx:424-446`の再生成ボタン表示条件を修正
 - **Technical**: 最後のbotメッセージかどうかの判定ロジック(`isLastBotMessage`)を追加
 
+### Recent Work Completed (2025/5/24 - お気に入り機能実装)
+- **Feature**: AIメッセージお気に入り機能を実装
+  - 新機能：AIメッセージにハートボタンを追加し、お気に入り登録/削除が可能
+  - 追加ファイル：`src/app/components/Favorites.tsx` (お気に入り一覧表示コンポーネント)
+  - 変更ファイル：`src/app/components/Chat.tsx` (お気に入りボタンとAPI機能追加)
+  - 変更ファイル：`src/app/components/Sidebar.tsx` (お気に入り表示ボタン追加)
+  - データ構造：`users/{userId}/favorites/{favoriteId}` - メッセージID、ルームID、本文、タイムスタンプを保存
+  - 主な機能：リアルタイム同期、お気に入り一覧表示、削除機能、メッセージ短縮表示
+
 ### Current Features Analysis
 - ✅ マルチルーム対応
 - ✅ 複数AIモデル対応（OpenAI/Claude）
@@ -88,12 +98,13 @@ Required in `chatapp/.env.local`:
 - ✅ メッセージ再生成（修正済み）
 - ✅ 既読機能
 - ✅ 履歴クリア
+- ✅ お気に入り機能（AIメッセージの保存・一覧表示）
 
 ## Next Actions
 
 ### 優先度高：実装推奨機能
-1. **メッセージ検索機能** - 過去の会話を効率的に検索
-2. **コードブロック シンタックスハイライト** - コード表示の改善
+1. **コードブロック シンタックスハイライト** - コード表示の改善
+2. **メッセージ検索機能** - 過去の会話を効率的に検索
 3. **メッセージ編集機能** - 送信済みメッセージの修正
 4. **ダークモード切り替え** - UI/UX改善
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,21 @@ Required in `chatapp/.env.local`:
 - **Solution**: `Chat.tsx:424-446`の再生成ボタン表示条件を修正
 - **Technical**: 最後のbotメッセージかどうかの判定ロジック(`isLastBotMessage`)を追加
 
-### Recent Work Completed (2025/5/24 - お気に入り機能実装)
+### Recent Work Completed (2024/12/30 - レスポンシブ&モデル比較&PRレビュー対応)
+- **Feature**: レスポンシブデザイン改善とAIモデル比較機能を実装
+  - レスポンシブデザイン：固定幅→完全レスポンシブ、モバイル用ハンバーガーメニュー実装
+  - AIモデル比較機能：4つのモデル(GPT-4o/mini, Claude-3-5-Sonnet/Haiku)で並列実行
+  - チャットヘッダー固定表示：スクロール時もコントロール部分が常に見える
+  - 新規ファイル：`src/app/components/ModelComparison.tsx`, `src/constants/models.ts`
+  - 変更ファイル：`src/app/page.tsx`, `src/app/components/Chat.tsx`, `src/app/components/Sidebar.tsx`
+
+- **PRレビュー対応**: コードレビューフィードバックに基づく品質向上
+  - `bg-custom-blue`未定義クラスを`bg-blue-900`に修正
+  - モデル定義を一元化（`constants/models.ts`）してDRY原則に準拠
+  - TypeScript型安全性向上：`ComparisonResult`型を明示的に使用
+  - アクセシビリティ改善：ハンバーガーメニューに`aria-label`、`aria-expanded`属性追加
+  - セマンティックHTML：サイドバーを`<nav>`要素に変更
+
 - **Feature**: AIメッセージお気に入り機能を実装
   - 新機能：AIメッセージにハートボタンを追加し、お気に入り登録/削除が可能
   - 追加ファイル：`src/app/components/Favorites.tsx` (お気に入り一覧表示コンポーネント)
@@ -99,6 +113,9 @@ Required in `chatapp/.env.local`:
 - ✅ 既読機能
 - ✅ 履歴クリア
 - ✅ お気に入り機能（AIメッセージの保存・一覧表示）
+- ✅ レスポンシブデザイン（モバイル対応完了）
+- ✅ AIモデル比較機能（4モデル並列実行）
+- ✅ 固定ヘッダー/フッター（スクロール時の操作性向上）
 
 ## Next Actions
 
@@ -118,3 +135,6 @@ Required in `chatapp/.env.local`:
 - 検索機能実装時はFirestore full-text searchの制限を考慮
 - シンタックスハイライトは`react-syntax-highlighter`ライブラリの導入を検討
 - 大量メッセージでのパフォーマンス最適化が必要
+- モデル比較機能のAPI使用量監視とコスト管理
+- アクセシビリティ対応の継続的改善
+- TypeScript型安全性の向上（`any`型の削除）

--- a/chatapp/src/app/components/Chat.tsx
+++ b/chatapp/src/app/components/Chat.tsx
@@ -6,7 +6,8 @@ import { FaCheck, FaCheckDouble, FaRedo, FaHeart, FaRegHeart } from "react-icons
 import { db } from "../../../firebase";
 import { addDoc, collection, doc, onSnapshot, orderBy, query, serverTimestamp, Timestamp, getDocs, deleteDoc, updateDoc } from "firebase/firestore";
 import { useAppContext } from "@/context/AppContext";
-import LoadingIcons from 'react-loading-icons'
+import LoadingIcons from 'react-loading-icons';
+import ModelComparison from './ModelComparison';
 
 type Message = {
   text: string;
@@ -27,6 +28,9 @@ const Chat = () => {
   const [streamingMessage, setStreamingMessage] = useState<string>("");
   const [regeneratingMessageId, setRegeneratingMessageId] = useState<string | null>(null);
   const [favorites, setFavorites] = useState<Set<string>>(new Set());
+  const [showComparison, setShowComparison] = useState<boolean>(false);
+  const [comparisonResults, setComparisonResults] = useState<any[]>([]);
+  const [comparisonQuestion, setComparisonQuestion] = useState<string>("");
 
   const scrollDiv = useRef<HTMLDivElement>(null);
 
@@ -394,6 +398,103 @@ const Chat = () => {
     return () => unsubscribe();
   }, [userId]);
 
+  // モデル比較機能
+  const compareModels = async (question: string, models: string[]) => {
+    setComparisonQuestion(question);
+    setShowComparison(true);
+    
+    // 初期状態を設定
+    const initialResults = models.map(model => ({
+      model,
+      response: "",
+      status: 'loading' as const
+    }));
+    setComparisonResults(initialResults);
+
+    // 各モデルで並列実行
+    const promises = models.map(async (model, index) => {
+      try {
+        const apiEndpoint = model.startsWith('claude') ? '/api/claude' : '/api/openai';
+        
+        const response = await fetch(apiEndpoint, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            inputMessage: question,
+            context: messages.map(message => ({
+              text: message.text,
+              sender: message.sender
+            })),
+            model: model
+          }),
+        });
+
+        if (!response.body) {
+          throw new Error('No response body');
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let fullResponse = '';
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          const chunk = decoder.decode(value);
+          const lines = chunk.split('\n');
+
+          for (const line of lines) {
+            if (line.startsWith('data: ')) {
+              const data = line.slice(6);
+              if (data === '[DONE]') {
+                break;
+              }
+              try {
+                const parsed = JSON.parse(data);
+                if (parsed.content) {
+                  fullResponse += parsed.content;
+                  // リアルタイム更新
+                  setComparisonResults(prev => prev.map((result, i) => 
+                    i === index 
+                      ? { ...result, response: fullResponse, status: 'loading' }
+                      : result
+                  ));
+                }
+              } catch (e) {
+                // Ignore JSON parsing errors
+              }
+            }
+          }
+        }
+
+        // 完了状態に更新
+        setComparisonResults(prev => prev.map((result, i) => 
+          i === index 
+            ? { ...result, response: fullResponse, status: 'completed' }
+            : result
+        ));
+
+      } catch (error) {
+        console.error(`Error with model ${model}:`, error);
+        setComparisonResults(prev => prev.map((result, i) => 
+          i === index 
+            ? { ...result, status: 'error', error: error instanceof Error ? error.message : 'Unknown error' }
+            : result
+        ));
+      }
+    });
+
+    await Promise.all(promises);
+  };
+
+  // 比較モードでの再生成
+  const handleComparisonRegenerate = (models: string[]) => {
+    compareModels(comparisonQuestion, models);
+  };
+
   // メッセージ履歴をクリアする関数
   const clearChatHistory = async () => {
     if (!selectedRoom) return;
@@ -415,21 +516,21 @@ const Chat = () => {
   };
 
   return (
-    <div className="bg-gray-500 h-full flex flex-col p-4">
-      <h1 className="text-2xl text-white font-semibold mb-4">{selectRoomName}</h1>
-      <div className="flex mb-4 space-x-4 flex-wrap"> {/* フレックスボックスを使用して横並びに */}
+    <div className="bg-gray-500 h-full flex flex-col p-2 sm:p-4">
+      <h1 className="text-xl sm:text-2xl text-white font-semibold mb-2 sm:mb-4 truncate">{selectRoomName}</h1>
+      <div className="flex mb-2 sm:mb-4 gap-2 sm:gap-4 flex-wrap"> {/* レスポンシブ対応のスペーシング */}
         <div className="flex items-center mb-2">
           <label className="text-white mr-2">AI Provider:</label>
           <span className="bg-blue-600 text-white px-2 py-1 rounded text-sm">
             {getCurrentAIProvider()}
           </span>
         </div>
-        <div className="mb-2">
-          <label className="text-white mr-2">Select AI Model:</label>
+        <div className="mb-2 flex-1 min-w-0">
+          <label className="text-white mr-2 text-sm sm:text-base">Select AI Model:</label>
           <select
             value={selectedModel}
             onChange={(e) => setSelectedModel(e.target.value)}
-            className="px-3 py-2 bg-white text-gray-700 appearance-none focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="w-full sm:w-auto px-2 sm:px-3 py-2 bg-white text-gray-700 appearance-none focus:outline-none focus:ring-1 focus:ring-blue-500 text-sm sm:text-base"
           >
             {modelOptions.map((option) => (
               <option key={option.value} value={option.value}>
@@ -438,13 +539,25 @@ const Chat = () => {
             ))}
           </select>
         </div>
-        <div className="mb-2">
+        <div className="mb-2 flex gap-2">
           <button
             onClick={clearChatHistory}
             disabled={!selectedRoom || messages.length === 0}
-            className="bg-red-500 hover:bg-red-600 text-white px-3 py-2 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+            className="bg-red-500 hover:bg-red-600 text-white px-2 sm:px-3 py-2 rounded disabled:opacity-50 disabled:cursor-not-allowed text-sm sm:text-base"
           >
             履歴クリア
+          </button>
+          <button
+            onClick={() => {
+              if (inputMessage.trim()) {
+                const selectedModels = ["gpt-4o", "gpt-4o-mini", "claude-3-5-sonnet-latest", "claude-3-5-haiku-latest"];
+                compareModels(inputMessage, selectedModels);
+              }
+            }}
+            disabled={!inputMessage.trim() || isLoading}
+            className="bg-purple-500 hover:bg-purple-600 text-white px-2 sm:px-3 py-2 rounded disabled:opacity-50 disabled:cursor-not-allowed text-sm sm:text-base"
+          >
+            モデル比較
           </button>
         </div>
       </div>
@@ -456,8 +569,8 @@ const Chat = () => {
                 <div
                   className={
                     message.sender === "user"
-                    ? "bg-blue-500 inline-block rounded px-4 py-2 mb-2 whitespace-pre-wrap max-w-xs md:max-w-md lg:max-w-lg"
-                    : "bg-green-500 inline-block rounded px-4 py-2 mb-2 whitespace-pre-wrap max-w-xs md:max-w-md lg:max-w-lg"
+                    ? "bg-blue-500 inline-block rounded px-3 sm:px-4 py-2 mb-2 whitespace-pre-wrap max-w-[280px] sm:max-w-xs md:max-w-md lg:max-w-lg"
+                    : "bg-green-500 inline-block rounded px-3 sm:px-4 py-2 mb-2 whitespace-pre-wrap max-w-[280px] sm:max-w-xs md:max-w-md lg:max-w-lg"
                       }
                 >
                 <p className="text-white">{message.text}</p>
@@ -527,7 +640,7 @@ const Chat = () => {
           ))}
           {streamingMessage && (
             <div className="text-left">
-              <div className="bg-green-500 inline-block rounded px-4 py-2 mb-2 whitespace-pre-wrap max-w-xs md:max-w-md lg:max-w-lg">
+              <div className="bg-green-500 inline-block rounded px-3 sm:px-4 py-2 mb-2 whitespace-pre-wrap max-w-[280px] sm:max-w-xs md:max-w-md lg:max-w-lg">
                 <p className="text-white">{streamingMessage}</p>
                 <span className="text-green-200 animate-pulse">▋</span>
                 <div className="text-xs mt-1 flex items-center justify-between text-green-200">
@@ -546,10 +659,10 @@ const Chat = () => {
           )}
           {isLoading && !streamingMessage && <LoadingIcons.TailSpin />}
       </div>
-      <div className="flex-shrink-0 relative">
+      <div className="flex-shrink-0 relative mx-1 sm:mx-0">
           <textarea
             ref={textareaRef}
-            className="w-full p-2 pr-10 rounded border-2 focus:outline-none resize-none overflow-hidden min-h-[40px]"
+            className="w-full p-2 sm:p-3 pr-12 sm:pr-14 rounded border-2 focus:outline-none resize-none overflow-hidden min-h-[40px] text-sm sm:text-base"
             placeholder="Type a message..."
             value={inputMessage}
             onCompositionStart={startComposition}
@@ -583,13 +696,21 @@ const Chat = () => {
             rows={1}
           />
           <button
-            className="absolute right-2 top-2 rounded"
+            className="absolute right-2 sm:right-3 top-2 sm:top-3 rounded p-1 hover:bg-gray-100"
             onClick={handleSendMessage}
           >
-            <GoPaperAirplane />
+            <GoPaperAirplane className="text-sm sm:text-base" />
           </button>
-          <span className="absolute right-2 bottom-1 text-xs text-gray-400 italic">⌘+Enter to send</span>
+          <span className="absolute right-2 sm:right-3 bottom-1 text-xs text-gray-400 italic">⌘+Enter to send</span>
         </div>
+      
+      <ModelComparison
+        isOpen={showComparison}
+        onClose={() => setShowComparison(false)}
+        question={comparisonQuestion}
+        results={comparisonResults}
+        onRegenerate={handleComparisonRegenerate}
+      />
     </div>
 
   );

--- a/chatapp/src/app/components/Chat.tsx
+++ b/chatapp/src/app/components/Chat.tsx
@@ -7,7 +7,8 @@ import { db } from "../../../firebase";
 import { addDoc, collection, doc, onSnapshot, orderBy, query, serverTimestamp, Timestamp, getDocs, deleteDoc, updateDoc } from "firebase/firestore";
 import { useAppContext } from "@/context/AppContext";
 import LoadingIcons from 'react-loading-icons';
-import ModelComparison from './ModelComparison';
+import ModelComparison, { ComparisonResult } from './ModelComparison';
+import { AI_MODELS, DEFAULT_COMPARISON_MODELS, getModelProvider, isClaudeModel } from '@/constants/models';
 
 type Message = {
   text: string;
@@ -29,7 +30,7 @@ const Chat = () => {
   const [regeneratingMessageId, setRegeneratingMessageId] = useState<string | null>(null);
   const [favorites, setFavorites] = useState<Set<string>>(new Set());
   const [showComparison, setShowComparison] = useState<boolean>(false);
-  const [comparisonResults, setComparisonResults] = useState<any[]>([]);
+  const [comparisonResults, setComparisonResults] = useState<ComparisonResult[]>([]);
   const [comparisonQuestion, setComparisonQuestion] = useState<string>("");
 
   const scrollDiv = useRef<HTMLDivElement>(null);
@@ -58,29 +59,9 @@ const Chat = () => {
     }
   };
 
-  // モデルの選択肢を配列で定義
-  const modelOptions = [
-    { value: "gpt-4o", label: "GPT-4o" },
-    { value: "gpt-4o-mini", label: "GPT-4o Mini" },
-    { value: "o1", label: "o1" },
-    { value: "o1-mini", label: "o1-mini" },
-    { value: "claude-3-7-sonnet-latest", label: "Claude-3-7-Sonnet" },
-    { value: "claude-3-5-sonnet-latest", label: "Claude-3-5-Sonnet" },
-    { value: "claude-3-5-haiku-latest", label: "Claude-3-5-Haiku" },
-  ];
-
-  // Check if the selected model is a Claude model
-  const isClaudeModel = (model: string): boolean => {
-    return model.startsWith('claude');
-  };
-
   // Get the current AI provider based on the selected model
   const getCurrentAIProvider = (): string => {
-    if (isClaudeModel(selectedModel)) {
-      return "Claude";
-    } else {
-      return "OpenAI";
-    }
+    return getModelProvider(selectedModel);
   };
 
     // Retrieve messages for the selected room from Firestore
@@ -534,9 +515,9 @@ const Chat = () => {
             onChange={(e) => setSelectedModel(e.target.value)}
             className="w-full sm:w-auto px-2 sm:px-3 py-2 bg-white text-gray-700 appearance-none focus:outline-none focus:ring-1 focus:ring-blue-500 text-sm sm:text-base"
           >
-            {modelOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
+            {AI_MODELS.map((model) => (
+              <option key={model.value} value={model.value}>
+                {model.label}
               </option>
             ))}
           </select>
@@ -552,8 +533,7 @@ const Chat = () => {
           <button
             onClick={() => {
               if (inputMessage.trim()) {
-                const selectedModels = ["gpt-4o", "gpt-4o-mini", "claude-3-5-sonnet-latest", "claude-3-5-haiku-latest"];
-                compareModels(inputMessage, selectedModels);
+                compareModels(inputMessage, DEFAULT_COMPARISON_MODELS);
               }
             }}
             disabled={!inputMessage.trim() || isLoading}

--- a/chatapp/src/app/components/Chat.tsx
+++ b/chatapp/src/app/components/Chat.tsx
@@ -516,9 +516,11 @@ const Chat = () => {
   };
 
   return (
-    <div className="bg-gray-500 h-full flex flex-col p-2 sm:p-4">
-      <h1 className="text-xl sm:text-2xl text-white font-semibold mb-2 sm:mb-4 truncate">{selectRoomName}</h1>
-      <div className="flex mb-2 sm:mb-4 gap-2 sm:gap-4 flex-wrap"> {/* レスポンシブ対応のスペーシング */}
+    <div className="bg-gray-500 h-full flex flex-col">
+      {/* 固定ヘッダー */}
+      <div className="flex-none bg-gray-500 p-2 sm:p-4 border-b border-gray-400">
+        <h1 className="text-xl sm:text-2xl text-white font-semibold mb-2 sm:mb-4 truncate">{selectRoomName}</h1>
+        <div className="flex mb-2 sm:mb-4 gap-2 sm:gap-4 flex-wrap"> {/* レスポンシブ対応のスペーシング */}
         <div className="flex items-center mb-2">
           <label className="text-white mr-2">AI Provider:</label>
           <span className="bg-blue-600 text-white px-2 py-1 rounded text-sm">
@@ -560,8 +562,11 @@ const Chat = () => {
             モデル比較
           </button>
         </div>
+        </div>
       </div>
-      <div ref={scrollDiv} className="flex-grow overflow-y-auto mb-4">
+      
+      {/* メッセージエリア */}
+      <div ref={scrollDiv} className="flex-1 overflow-y-auto p-2 sm:p-4 pb-0 min-h-0">
           {messages.map((message, index) => (
             <div
               key={index}
@@ -659,7 +664,10 @@ const Chat = () => {
           )}
           {isLoading && !streamingMessage && <LoadingIcons.TailSpin />}
       </div>
-      <div className="flex-shrink-0 relative mx-1 sm:mx-0">
+      
+      {/* 固定入力エリア */}
+      <div className="flex-none bg-gray-500 p-2 sm:p-4 border-t border-gray-400">
+        <div className="relative">
           <textarea
             ref={textareaRef}
             className="w-full p-2 sm:p-3 pr-12 sm:pr-14 rounded border-2 focus:outline-none resize-none overflow-hidden min-h-[40px] text-sm sm:text-base"
@@ -703,6 +711,7 @@ const Chat = () => {
           </button>
           <span className="absolute right-2 sm:right-3 bottom-1 text-xs text-gray-400 italic">⌘+Enter to send</span>
         </div>
+      </div>
       
       <ModelComparison
         isOpen={showComparison}

--- a/chatapp/src/app/components/ModelComparison.tsx
+++ b/chatapp/src/app/components/ModelComparison.tsx
@@ -3,8 +3,9 @@
 import React, { useState } from "react";
 import { FaTimes, FaRedo, FaCheck } from "react-icons/fa";
 import LoadingIcons from 'react-loading-icons';
+import { getModelDisplayName, getModelProvider } from '@/constants/models';
 
-type ComparisonResult = {
+export type ComparisonResult = {
   model: string;
   response: string;
   status: 'loading' | 'completed' | 'error';
@@ -21,25 +22,6 @@ type ModelComparisonProps = {
 
 const ModelComparison = ({ isOpen, onClose, question, results, onRegenerate }: ModelComparisonProps) => {
   const [selectedModels, setSelectedModels] = useState<string[]>([]);
-
-  // モデル表示名の取得
-  const getModelDisplayName = (model: string) => {
-    const modelMap: { [key: string]: string } = {
-      "gpt-4o": "GPT-4o",
-      "gpt-4o-mini": "GPT-4o Mini",
-      "o1": "o1",
-      "o1-mini": "o1-mini",
-      "claude-3-7-sonnet-latest": "Claude-3-7-Sonnet",
-      "claude-3-5-sonnet-latest": "Claude-3-5-Sonnet",
-      "claude-3-5-haiku-latest": "Claude-3-5-Haiku",
-    };
-    return modelMap[model] || model;
-  };
-
-  // プロバイダーの取得
-  const getProvider = (model: string) => {
-    return model.startsWith('claude') ? 'Claude' : 'OpenAI';
-  };
 
   // レスポンスの文字数カウント
   const getResponseLength = (response: string) => {
@@ -110,11 +92,11 @@ const ModelComparison = ({ isOpen, onClose, question, results, onRegenerate }: M
                       {getModelDisplayName(result.model)}
                     </h3>
                     <span className={`text-xs px-2 py-1 rounded ${
-                      getProvider(result.model) === 'Claude' 
+                      getModelProvider(result.model) === 'Claude' 
                         ? 'bg-orange-100 text-orange-700' 
                         : 'bg-green-100 text-green-700'
                     }`}>
-                      {getProvider(result.model)}
+                      {getModelProvider(result.model)}
                     </span>
                   </div>
                   <div className="flex items-center gap-2">

--- a/chatapp/src/app/components/ModelComparison.tsx
+++ b/chatapp/src/app/components/ModelComparison.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import React, { useState } from "react";
+import { FaTimes, FaRedo, FaCheck } from "react-icons/fa";
+import LoadingIcons from 'react-loading-icons';
+
+type ComparisonResult = {
+  model: string;
+  response: string;
+  status: 'loading' | 'completed' | 'error';
+  error?: string;
+};
+
+type ModelComparisonProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  question: string;
+  results: ComparisonResult[];
+  onRegenerate: (models: string[]) => void;
+};
+
+const ModelComparison = ({ isOpen, onClose, question, results, onRegenerate }: ModelComparisonProps) => {
+  const [selectedModels, setSelectedModels] = useState<string[]>([]);
+
+  // モデル表示名の取得
+  const getModelDisplayName = (model: string) => {
+    const modelMap: { [key: string]: string } = {
+      "gpt-4o": "GPT-4o",
+      "gpt-4o-mini": "GPT-4o Mini",
+      "o1": "o1",
+      "o1-mini": "o1-mini",
+      "claude-3-7-sonnet-latest": "Claude-3-7-Sonnet",
+      "claude-3-5-sonnet-latest": "Claude-3-5-Sonnet",
+      "claude-3-5-haiku-latest": "Claude-3-5-Haiku",
+    };
+    return modelMap[model] || model;
+  };
+
+  // プロバイダーの取得
+  const getProvider = (model: string) => {
+    return model.startsWith('claude') ? 'Claude' : 'OpenAI';
+  };
+
+  // レスポンスの文字数カウント
+  const getResponseLength = (response: string) => {
+    return response.length;
+  };
+
+  // 再生成
+  const handleRegenerate = () => {
+    if (selectedModels.length > 0) {
+      onRegenerate(selectedModels);
+      setSelectedModels([]);
+    }
+  };
+
+  // モデル選択の切り替え
+  const toggleModelSelection = (model: string) => {
+    setSelectedModels(prev => 
+      prev.includes(model) 
+        ? prev.filter(m => m !== model)
+        : [...prev, model]
+    );
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg w-full max-w-7xl h-5/6 flex flex-col">
+        {/* ヘッダー */}
+        <div className="flex items-center justify-between p-4 border-b">
+          <div className="flex-1">
+            <h2 className="text-xl font-semibold text-gray-800">AIモデル比較</h2>
+            <p className="text-sm text-gray-600 mt-1 break-words">{question}</p>
+          </div>
+          <div className="flex items-center gap-2 ml-4">
+            {selectedModels.length > 0 && (
+              <button
+                onClick={handleRegenerate}
+                className="bg-blue-500 hover:bg-blue-600 text-white px-3 py-2 rounded flex items-center gap-2"
+              >
+                <FaRedo className="text-sm" />
+                再生成 ({selectedModels.length})
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              className="text-gray-500 hover:text-gray-700 p-2"
+            >
+              <FaTimes />
+            </button>
+          </div>
+        </div>
+
+        {/* コンテンツ */}
+        <div className="flex-1 overflow-y-auto p-4">
+          <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
+            {results.map((result) => (
+              <div
+                key={result.model}
+                className={`border rounded-lg p-4 h-full flex flex-col ${
+                  selectedModels.includes(result.model) ? 'border-blue-500 bg-blue-50' : 'border-gray-200'
+                }`}
+              >
+                {/* モデル情報 */}
+                <div className="flex items-center justify-between mb-3">
+                  <div>
+                    <h3 className="font-semibold text-gray-800">
+                      {getModelDisplayName(result.model)}
+                    </h3>
+                    <span className={`text-xs px-2 py-1 rounded ${
+                      getProvider(result.model) === 'Claude' 
+                        ? 'bg-orange-100 text-orange-700' 
+                        : 'bg-green-100 text-green-700'
+                    }`}>
+                      {getProvider(result.model)}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {result.status === 'completed' && (
+                      <input
+                        type="checkbox"
+                        checked={selectedModels.includes(result.model)}
+                        onChange={() => toggleModelSelection(result.model)}
+                        className="w-4 h-4 text-blue-600"
+                      />
+                    )}
+                    {result.status === 'completed' && (
+                      <FaCheck className="text-green-500" />
+                    )}
+                  </div>
+                </div>
+
+                {/* ステータス別表示 */}
+                <div className="flex-1 flex flex-col">
+                  {result.status === 'loading' && (
+                    <div className="flex-1 flex items-center justify-center">
+                      <div className="text-center">
+                        <LoadingIcons.TailSpin stroke="#6B7280" />
+                        <p className="text-gray-500 mt-2">生成中...</p>
+                      </div>
+                    </div>
+                  )}
+
+                  {result.status === 'error' && (
+                    <div className="flex-1 flex items-center justify-center">
+                      <div className="text-center text-red-500">
+                        <p className="font-medium">エラーが発生しました</p>
+                        <p className="text-sm mt-1">{result.error}</p>
+                      </div>
+                    </div>
+                  )}
+
+                  {result.status === 'completed' && (
+                    <>
+                      <div className="bg-gray-50 rounded p-3 flex-1 overflow-y-auto">
+                        <p className="whitespace-pre-wrap text-sm text-gray-800 break-words">
+                          {result.response}
+                        </p>
+                      </div>
+                      <div className="mt-2 text-xs text-gray-500">
+                        {getResponseLength(result.response)} 文字
+                      </div>
+                    </>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ModelComparison;

--- a/chatapp/src/app/components/Sidebar.tsx
+++ b/chatapp/src/app/components/Sidebar.tsx
@@ -100,7 +100,7 @@ const Sidebar = ({ onClose }: SidebarProps) => {
   }
 
   return (
-    <div className="bg-custom-blue h-full overflow-y-auto px-5 flex flex-col">
+    <div className="bg-blue-900 h-full overflow-y-auto px-5 flex flex-col">
       <div className="flex-grow">
         <div
           onClick={addRoom}

--- a/chatapp/src/app/components/Sidebar.tsx
+++ b/chatapp/src/app/components/Sidebar.tsx
@@ -12,7 +12,11 @@ type Room = {
   createdAt: Timestamp;
 };
 
-const Sidebar = () => {
+type SidebarProps = {
+  onClose?: () => void;
+};
+
+const Sidebar = ({ onClose }: SidebarProps) => {
 
   const { user, userId, setSelectedRoom, setSelectRoomName, selectedRoom } = useAppContext();
 
@@ -46,6 +50,8 @@ const Sidebar = () => {
     console.log(roomId);
     setSelectedRoom(roomId);
     setSelectRoomName(roomName);
+    // モバイルでルーム選択時にサイドバーを閉じる
+    onClose?.();
   };
 
   // Add a new room

--- a/chatapp/src/app/page.tsx
+++ b/chatapp/src/app/page.tsx
@@ -4,15 +4,50 @@ import Sidebar from "./components/Sidebar";
 import Chat from "./components/Chat";
 import { useAppContext } from "@/context/AppContext";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { FaBars, FaTimes } from "react-icons/fa";
 
 export default function Home() {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
   return (
-    <div className="h-screen flex flex-col items-center justify-center">
-      <div className="h-full flex" style={{ width: "1280px"}}>
-        <div className="w-1/5 h-full border-r">
-          <Sidebar />
+    <div className="h-screen flex relative">
+      {/* モバイル用サイドバーオーバーレイ */}
+      {isSidebarOpen && (
+        <div 
+          className="fixed inset-0 bg-black bg-opacity-50 z-40 lg:hidden"
+          onClick={() => setIsSidebarOpen(false)}
+        />
+      )}
+      
+      {/* サイドバー */}
+      <div className={`
+        fixed lg:static inset-y-0 left-0 z-50 
+        w-80 lg:w-1/4 xl:w-1/5 
+        transform transition-transform duration-300 ease-in-out
+        lg:transform-none lg:transition-none
+        ${isSidebarOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'}
+        border-r
+      `}>
+        <Sidebar onClose={() => setIsSidebarOpen(false)} />
+      </div>
+
+      {/* メインコンテンツ */}
+      <div className="flex-1 flex flex-col lg:ml-0">
+        {/* モバイル用ヘッダー */}
+        <div className="lg:hidden bg-custom-blue text-white p-4 flex items-center justify-between">
+          <button
+            onClick={() => setIsSidebarOpen(!isSidebarOpen)}
+            className="text-white p-2 hover:bg-blue-700 rounded"
+          >
+            <FaBars size={20} />
+          </button>
+          <h1 className="text-lg font-semibold">AI Chat</h1>
+          <div className="w-8" /> {/* スペーサー */}
         </div>
-        <div className="w-4/5 h-full bg-blue-200">
+
+        {/* チャットエリア */}
+        <div className="flex-1 bg-blue-200">
           <Chat />
         </div>
       </div>

--- a/chatapp/src/app/page.tsx
+++ b/chatapp/src/app/page.tsx
@@ -21,24 +21,29 @@ export default function Home() {
       )}
       
       {/* サイドバー */}
-      <div className={`
-        fixed lg:static inset-y-0 left-0 z-50 
-        w-80 lg:w-1/4 xl:w-1/5 
-        transform transition-transform duration-300 ease-in-out
-        lg:transform-none lg:transition-none
-        ${isSidebarOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'}
-        border-r
-      `}>
+      <nav 
+        className={`
+          fixed lg:static inset-y-0 left-0 z-50 
+          w-80 lg:w-1/4 xl:w-1/5 
+          transform transition-transform duration-300 ease-in-out
+          lg:transform-none lg:transition-none
+          ${isSidebarOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'}
+          border-r
+        `}
+        aria-label="メインナビゲーション"
+      >
         <Sidebar onClose={() => setIsSidebarOpen(false)} />
-      </div>
+      </nav>
 
       {/* メインコンテンツ */}
       <div className="flex-1 flex flex-col lg:ml-0">
         {/* モバイル用ヘッダー */}
-        <div className="lg:hidden bg-custom-blue text-white p-4 flex items-center justify-between">
+        <div className="lg:hidden bg-blue-900 text-white p-4 flex items-center justify-between">
           <button
             onClick={() => setIsSidebarOpen(!isSidebarOpen)}
             className="text-white p-2 hover:bg-blue-700 rounded"
+            aria-label={isSidebarOpen ? "サイドバーを閉じる" : "サイドバーを開く"}
+            aria-expanded={isSidebarOpen}
           >
             <FaBars size={20} />
           </button>

--- a/chatapp/src/app/page.tsx
+++ b/chatapp/src/app/page.tsx
@@ -47,7 +47,7 @@ export default function Home() {
         </div>
 
         {/* チャットエリア */}
-        <div className="flex-1 bg-blue-200">
+        <div className="flex-1 bg-blue-200 min-h-0">
           <Chat />
         </div>
       </div>

--- a/chatapp/src/constants/models.ts
+++ b/chatapp/src/constants/models.ts
@@ -1,0 +1,36 @@
+export type AIModel = {
+  value: string;
+  label: string;
+  provider: 'OpenAI' | 'Claude';
+};
+
+export const AI_MODELS: AIModel[] = [
+  { value: "gpt-4o", label: "GPT-4o", provider: 'OpenAI' },
+  { value: "gpt-4o-mini", label: "GPT-4o Mini", provider: 'OpenAI' },
+  { value: "o1", label: "o1", provider: 'OpenAI' },
+  { value: "o1-mini", label: "o1-mini", provider: 'OpenAI' },
+  { value: "claude-3-7-sonnet-latest", label: "Claude-3-7-Sonnet", provider: 'Claude' },
+  { value: "claude-3-5-sonnet-latest", label: "Claude-3-5-Sonnet", provider: 'Claude' },
+  { value: "claude-3-5-haiku-latest", label: "Claude-3-5-Haiku", provider: 'Claude' },
+];
+
+export const DEFAULT_COMPARISON_MODELS = [
+  "gpt-4o",
+  "gpt-4o-mini", 
+  "claude-3-5-sonnet-latest",
+  "claude-3-5-haiku-latest"
+];
+
+export const getModelDisplayName = (modelValue: string): string => {
+  const model = AI_MODELS.find(m => m.value === modelValue);
+  return model?.label || modelValue;
+};
+
+export const getModelProvider = (modelValue: string): 'OpenAI' | 'Claude' => {
+  const model = AI_MODELS.find(m => m.value === modelValue);
+  return model?.provider || 'OpenAI';
+};
+
+export const isClaudeModel = (modelValue: string): boolean => {
+  return getModelProvider(modelValue) === 'Claude';
+};


### PR DESCRIPTION
## Summary
- レスポンシブデザインの大幅改善でモバイル対応を強化
- 複数AIモデルの並列比較機能を追加し、ユーザー体験を向上

## 主な変更内容

### レスポンシブデザイン改善
- 固定幅レイアウト（1280px）を完全レスポンシブに変更
- モバイル用ハンバーガーメニューとサイドバー開閉機能を実装
- テキストサイズ、スペーシング、ボタンサイズをブレイクポイント別に最適化
- メッセージ表示幅をデバイスサイズに応じて調整（280px-lg）
- タッチ操作に配慮したボタンサイズとクリック領域の拡大

### AIモデル比較機能
- 同じ質問を4つのモデルで並列実行
  - GPT-4o, GPT-4o-mini
  - Claude-3-5-Sonnet, Claude-3-5-Haiku
- リアルタイムストリーミング対応の比較結果表示
- 個別モデルの選択的再生成機能
- 回答の文字数カウントとプロバイダー表示
- レスポンシブな3カラムグリッドレイアウト（lg:2列、xl:3列）

## 技術的な詳細

### ファイル変更
- `page.tsx`: レスポンシブレイアウトとモバイルヘッダー追加
- `Chat.tsx`: モデル比較機能とレスポンシブUI改善
- `Sidebar.tsx`: モバイル対応の閉じる機能追加
- `ModelComparison.tsx`: 新規作成（比較結果表示コンポーネント）
- `CLAUDE.md`: ドキュメント更新

### UX改善
- モバイルでルーム選択後に自動でサイドバーが閉じる
- ボタンのホバー効果とタッチフィードバック追加
- テキスト切り詰め（truncate）で長いルーム名に対応
- モバイルファーストなレスポンシブブレイクポイント設計

## Test plan
- [ ] デスクトップ表示の確認
- [ ] タブレット表示の確認
- [ ] モバイル表示の確認
- [ ] サイドバー開閉動作の確認
- [ ] モデル比較機能の動作確認
- [ ] 各AIモデルの並列処理動作確認
- [ ] ストリーミング表示の確認
- [ ] 再生成機能の確認

🤖 Generated with [Claude Code](https://claude.ai/code)